### PR TITLE
Add encoding line for python2 clients.

### DIFF
--- a/psychphinder.py
+++ b/psychphinder.py
@@ -1,3 +1,4 @@
+# coding: UTF-8
 import pandas as pd
 from colorama import init, Style
 import sys


### PR DESCRIPTION
Hello,

This PR addresses issue #1 by adding the appropriate "encoding" line.

Fixes #1 